### PR TITLE
Allow reading multi-series files

### DIFF
--- a/apeer_ometiff_library/io.py
+++ b/apeer_ometiff_library/io.py
@@ -1,7 +1,55 @@
+from pathlib import Path
+from types import TracebackType
+from typing import Union, Optional, Type, Tuple, List
+
 import tifffile
 import numpy as np
 import sys
-from apeer_ometiff_library import omexmlClass 
+from apeer_ometiff_library import omexmlClass
+
+PathLike = Union[str, Path]
+
+
+class OmeTiffFile:
+    def __init__(self, path: PathLike):
+        self._path = path
+        self._tiff_file = tifffile.TiffFile(self._path)
+
+    def __enter__(self) -> "OmeTiffFile":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool:
+        self.close()
+        return False
+
+    def close(self) -> None:
+        self._tiff_file.close()
+
+    @property
+    def is_multi_series(self):
+        return omexmlClass.OMEXML(self._tiff_file.ome_metadata).image_count > 1
+
+    def read(self) -> Tuple[np.ndarray, str]:
+        omexml_string = self._tiff_file.ome_metadata
+        array = _ensure_correct_dimensions(self._tiff_file.asarray(), omexml_string)
+        return array, omexml_string
+
+    def read_multi_series(self) -> Tuple[List[np.ndarray], str]:
+        omexml_string = self._tiff_file.ome_metadata
+        arrays = [
+            _ensure_correct_dimensions(
+                self._tiff_file.asarray(series=series), omexml_string
+            )
+            for series in range(
+                omexmlClass.OMEXML(self._tiff_file.ome_metadata).image_count
+            )
+        ]
+        return arrays, omexml_string
 
 
 def read_ometiff(input_path):
@@ -9,6 +57,12 @@ def read_ometiff(input_path):
         array = tif.asarray()
         omexml_string = tif.ome_metadata
 
+    array = _ensure_correct_dimensions(array, omexml_string)
+
+    return array, omexml_string
+
+
+def _ensure_correct_dimensions(array, omexml_string):
     # Turn Ome XML String to an Bioformats object for parsing
     metadata = omexmlClass.OMEXML(omexml_string)
 
@@ -19,10 +73,8 @@ def read_ometiff(input_path):
     size_z = pixels.SizeZ
     size_x = pixels.SizeX
     size_y = pixels.SizeY
-
     # Expand image array to 5D and make sure to return the array in (T, Z, C, X, Y) order
     dim_format = pixels.DimensionOrder
-
     if dim_format == "XYCZT":
         if size_c == 1:
             array = np.expand_dims(array, axis=-3)
@@ -75,8 +127,8 @@ def read_ometiff(input_path):
     else:
         print(array.shape)
         raise Exception("Unknow dimension format")
+    return array
 
-    return array, omexml_string
 
 def update_xml(omexml, Image_ID=None, Image_Name=None, Image_AcquisitionDate=None,
                DimensionOrder=None, dType=None, SizeT=None, SizeZ=None, SizeC=None, SizeX=None, SizeY=None,
@@ -112,51 +164,51 @@ def update_xml(omexml, Image_ID=None, Image_Name=None, Image_AcquisitionDate=Non
         metadata.image().Channel.Name = Channel_Name
     if Channel_SamplesPerPixel:
         metadata.image().Channel.SamplesPerPixel = Channel_SamplesPerPixel
-    
+
     metadata = metadata.to_xml().encode()
-    
+
     return metadata
 
 
 def gen_xml(array):
-    
+
     #Dimension order is assumed to be TZCYX
     dim_order = "TZCYX"
-    
+
     metadata = omexmlClass.OMEXML()
     shape = array.shape
     assert ( len(shape) == 5), "Expected array of 5 dimensions"
-    
+
     metadata.image().set_Name("IMAGE")
     metadata.image().set_ID("0")
-    
+
     pixels = metadata.image().Pixels
     pixels.ome_uuid = metadata.uuidStr
     pixels.set_ID("0")
-    
+
     pixels.channel_count = shape[2]
-    
+
     pixels.set_SizeT(shape[0])
     pixels.set_SizeZ(shape[1])
     pixels.set_SizeC(shape[2])
     pixels.set_SizeY(shape[3])
     pixels.set_SizeX(shape[4])
-    
+
     pixels.set_DimensionOrder(dim_order[::-1])
-    
+
     pixels.set_PixelType(omexmlClass.get_pixel_type(array.dtype))
-    
+
     for i in range(pixels.SizeC):
         pixels.Channel(i).set_ID("Channel:0:" + str(i))
         pixels.Channel(i).set_Name("C:" + str(i))
-    
+
     for i in range(pixels.SizeC):
         pixels.Channel(i).set_SamplesPerPixel(1)
-        
+
     pixels.populate_TiffData()
-    
+
     return metadata.to_xml().encode()
-    
+
 
 
 def write_ometiff(output_path, array, omexml_string = None, compression=None):
@@ -172,12 +224,12 @@ def write_ometiff(output_path, array, omexml_string = None, compression=None):
     omexml_string : Optional[encoded xml]
         encoded XML Metadata, will be generated if not provided.
     compression : str
-        possible values listed here: 
-        https://github.com/cgohlke/tifffile/blob/f55fc8a49c2ad30697a6b1760d5a325533574ad8/tifffile/tifffile.py#L12131 
+        possible values listed here:
+        https://github.com/cgohlke/tifffile/blob/f55fc8a49c2ad30697a6b1760d5a325533574ad8/tifffile/tifffile.py#L12131
     """
     if omexml_string is None:
         omexml_string = gen_xml(array)
-        
+
     if sys.version < "3.7":
         tifffile.imwrite(output_path, array,  photometric = "minisblack", description=omexml_string, metadata=None,
                          compress=compression)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 from setuptools import setup
 
 setup(name='apeer-ometiff-library',
-      version='1.8.3',
+      version='1.9.0',
       description='Library to read and write ometiff images',
       url='https://github.com/apeer-micro/apeer-ometiff-library',
       author='apeer-micro',

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,107 @@
+import unittest
+from pathlib import Path
+
+import numpy as np
+import tifffile
+
+from apeer_ometiff_library.io import OmeTiffFile
+
+
+class TestOmeTiffFile(unittest.TestCase):
+    def setUp(self):
+        self._set_up_ometiff()
+        self._set_up_multi_series_ometiff()
+
+    def _set_up_ometiff(self):
+        self.ometiff_path = Path("tmp.ome.tiff")
+        self.ometiff_path.touch()
+        self.ome_tiff_metadata = """<?xml version='1.0' encoding='utf-8'?>
+        <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"
+             UUID="urn:uuid:11227ecd-e960-42e4-95c8-39e6cec94150">
+            <Image ID="0" Name="IMAGE0">
+                <AcquisitionDate>2022-05-13T11:25:25.212054</AcquisitionDate>
+                <Pixels DimensionOrder="XYCZT" ID="0" SizeC="1" SizeT="1" SizeX="64" SizeY="32" SizeZ="1" Type="uint8"
+                        BigEndian="true">
+                    <Channel ID="Channel:0:0" SamplesPerPixel="1" Name="C:0">
+                        <LightPath/>
+                    </Channel>
+                    <TiffData FirstT="0" FirstZ="0" FirstC="0" IFD="0" PlaneCount="1"/>
+                </Pixels>
+            </Image>
+        </OME>""".encode()
+        self.ometiff_array = 255 * np.ones((1, 1, 1, 32, 64), np.uint8)
+        with tifffile.TiffWriter(self.ometiff_path) as tiff_writer:
+            tiff_writer.write(
+                self.ometiff_array,
+                photometric="minisblack",
+                description=self.ome_tiff_metadata,
+                metadata=None,
+            )
+
+    def _set_up_multi_series_ometiff(self):
+        self.multi_series_ometiff_path = Path("multi_series_tmp.ome.tiff")
+        self.multi_series_ometiff_path.touch()
+        self.multi_series_metadata = """<?xml version='1.0' encoding='utf-8'?>
+        <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"
+             UUID="urn:uuid:11227ecd-e960-42e4-95c8-39e6cec94150">
+            <Image ID="0" Name="IMAGE0">
+                <AcquisitionDate>2022-05-13T11:25:25.212054</AcquisitionDate>
+                <Pixels DimensionOrder="XYCZT" ID="0" SizeC="1" SizeT="1" SizeX="64" SizeY="32" SizeZ="1" Type="uint8"
+                        BigEndian="true">
+                    <Channel ID="Channel:0:0" SamplesPerPixel="1" Name="C:0">
+                        <LightPath/>
+                    </Channel>
+                    <TiffData FirstT="0" FirstZ="0" FirstC="0" IFD="0" PlaneCount="1"/>
+                </Pixels>
+            </Image>
+            <Image ID="1" Name="IMAGE1">
+                <AcquisitionDate>2022-05-13T11:25:25.212054</AcquisitionDate>
+                <Pixels DimensionOrder="XYCZT" ID="0" SizeC="1" SizeT="1" SizeX="32" SizeY="64" SizeZ="1" Type="uint8"
+                        BigEndian="true">
+                    <Channel ID="Channel:0:0" SamplesPerPixel="1" Name="C:0">
+                        <LightPath/>
+                    </Channel>
+                    <TiffData FirstT="0" FirstZ="0" FirstC="0" IFD="0" PlaneCount="1"/>
+                </Pixels>
+            </Image>
+        </OME>""".encode()
+        self.multi_series_ometiff_array0 = 255 * np.ones((1, 1, 1, 32, 64), np.uint8)
+        self.multi_series_ometiff_array1 = np.zeros((1, 1, 1, 64, 32), np.uint8)
+        with tifffile.TiffWriter(self.multi_series_ometiff_path) as tiff_writer:
+            tiff_writer.write(
+                self.multi_series_ometiff_array0,
+                photometric="minisblack",
+                metadata=None,
+            )
+            tiff_writer.write(
+                self.multi_series_ometiff_array1,
+                photometric="minisblack",
+                description=self.multi_series_metadata,
+                metadata=None,
+            )
+
+    def tearDown(self) -> None:
+        self.ometiff_path.unlink()
+        self.multi_series_ometiff_path.unlink()
+
+    def test_is_multi_series(self):
+        with OmeTiffFile(self.ometiff_path) as ome_tiff_file:
+            self.assertFalse(ome_tiff_file.is_multi_series)
+
+        with OmeTiffFile(self.multi_series_ometiff_path) as ome_tiff_file:
+            self.assertTrue(ome_tiff_file.is_multi_series)
+
+    def test_read(self):
+        with OmeTiffFile(self.ometiff_path) as ome_tiff_file:
+            array, omexml_string = ome_tiff_file.read()
+            np.testing.assert_equal(array, self.ometiff_array)
+
+    def test_read_multi_series(self):
+        with OmeTiffFile(self.multi_series_ometiff_path) as ome_tiff_file:
+            arrays, omexml_string = ome_tiff_file.read_multi_series()
+            np.testing.assert_equal(
+                arrays,
+                [self.multi_series_ometiff_array0, self.multi_series_ometiff_array1],
+            )


### PR DESCRIPTION
This PR Introduces `OmeTiffFile` class, which allows reading both single and multi-series OME-TIFF files.

The `OmeTiffFile`  class should be used as a context manager. Otherwise one needs to explicitly call `close` after file has been processed.

`read` can be used to read single series images, and it will behave the same as `read_ometiff` function. Multi series images can be read with `read`, but returned array will represent only the first image from the series.

To read multi-series images, use `read_multi_series`. The method works as well for single series images, just note that the returned list of arrays will have one element.

There is also an utility `is_multi_series` property do help determine which type of reading may be more convenient for your use case.

