### PR TITLE
Allow newer version of numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ import setuptools
 from setuptools import setup
 
 setup(name='apeer-ometiff-library',
-      version='1.10.0',
+      version='1.10.1',
       description='Library to read and write ometiff images',
       url='https://github.com/apeer-micro/apeer-ometiff-library',
       author='apeer-micro',
       packages=setuptools.find_packages(),
-      install_requires=['numpy==1.18.5','tifffile==2020.6.3', 'imagecodecs==2020.5.30'],
+      install_requires=['numpy>=1.18.5','tifffile==2020.6.3', 'imagecodecs==2020.5.30'],
       license='MIT',
       classifiers=[
           "Programming Language :: Python :: 3",


### PR DESCRIPTION
As per the [Python Packaging User Guide](https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/#install-requires):
> It is not considered best practice to use install_requires to pin dependencies to specific versions, [...]. This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.

While `tifffile` fixed version is explained by the need to maintain compatibility with different Python versions, imposing a single version for `numpy` restricts this library usability with other packages requiring `numpy` too.