### PR TITLE
FIX: Allow newer versions of imagecodecs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='apeer-ometiff-library',
       url='https://github.com/apeer-micro/apeer-ometiff-library',
       author='apeer-micro',
       packages=setuptools.find_packages(),
-      install_requires=['numpy>=1.18.5','tifffile==2020.6.3', 'imagecodecs==2020.5.30'],
+      install_requires=['numpy>=1.18.5','tifffile==2020.6.3', 'imagecodecs>=2020.5.30'],
       license='MIT',
       classifiers=[
           "Programming Language :: Python :: 3",


### PR DESCRIPTION
With the required version of imagecodecs, installing with pip fails due to the following error:

>       imagecodecs/_jpeg2k.c:788:10: fatal error: openjpeg.h: No such file or directory
>         788 | #include "openjpeg.h"
>             |          ^~~~~~~~~~~~
>       compilation terminated.
>       error: command '/usr/bin/gcc' failed with exit code 1

It is probably because it is using a deprecated version of libobenjpeg.
Allowing newer imagecodecs fixes this error for me, and the install goes smoothly.